### PR TITLE
YQLGradeDist

### DIFF
--- a/src/inject/cape.js
+++ b/src/inject/cape.js
@@ -45,7 +45,6 @@ Cape.prototype.getNewData = function (teacher, course, callback) {
             return callback();
         }
         var hrefValue = page.find('#ctl00_ContentPlaceHolder1_gvCAPEs_ctl02_hlViewReport').attr('href')
-        console.log("href: " + hrefValue)
 
         this.data = {
             enrolled: $(result[3]).text(),

--- a/src/inject/cape.js
+++ b/src/inject/cape.js
@@ -44,6 +44,8 @@ Cape.prototype.getNewData = function (teacher, course, callback) {
             this.data = null;
             return callback();
         }
+        var hrefValue = page.find('#ctl00_ContentPlaceHolder1_gvCAPEs_ctl02_hlViewReport').attr('href')
+        console.log("href: " + hrefValue)
 
         this.data = {
             enrolled: $(result[3]).text(),

--- a/src/inject/gradeDist.js
+++ b/src/inject/gradeDist.js
@@ -18,11 +18,6 @@ GradeDist.prototype.getNewData = function (teacher, course, callback) {
     this.fetchHTMLHttp("", function (page) {
         return callback();
     }.bind(this));
-    // debug
-    // console.log("teacher.lname: " + teacher.lname);
-    // console.log("teacher.lname: " + teacher.fname);
-    // console.log("teacher.lname: " + course.subjectCode);
-    // console.log("teacher.lname: " + course.courseCode);
 
     // link to professor's cape.ucsd.edu site in order to get their 6 digit page number 
     // YQL Query URL: select href from html where url = 'https://cape.ucsd.edu/responses/Results.aspx?Name=mirza%2Cdiba&CourseNumber=cse30' and xpath = '//*[@id="ctl00_ContentPlaceHolder1_gvCAPEs_ctl02_hlViewReport"]'

--- a/src/inject/gradeDist.js
+++ b/src/inject/gradeDist.js
@@ -19,78 +19,62 @@ GradeDist.prototype.getNewData = function (teacher, course, callback) {
     var link = "https://query.yahooapis.com/v1/public/yql?q=select%20href%20from%20html%20where%20url%3D%22https%3A%2F%2Fcape.ucsd.edu%2Fresponses%2FResults.aspx%3FName%3D" 
         + teacher.lname + "%252C%2B" + teacher.fname + "%26CourseNumber%3D" 
         + course.subjectCode + course.courseCode + "%22%20and%20xpath%3D'%2F%2F*%5B%40id%3D%22ctl00_ContentPlaceHolder1_gvCAPEs_ctl02_hlViewReport%22%5D'&format=json&diagnostics=true&callback=";
-    var jsonObj;
-    
-    // Create an XMLHttpRequest object to obtain data from websites
-    var request = new XMLHttpRequest();  
-    var sectionID = getSectionID(request, link);
-    // url to allow the user to go to the cape.ucsd.edu grade distribution site 
-    var url = "http://cape.ucsd.edu/responses/CAPEReport.aspx?sectionid=" + sectionID;
 
-    // get grade distribution data and display it to the user
-    // YQL Query URL: select td from html where url = 'https://cape.ucsd.edu/responses/CAPEReport.aspx?sectionid=849783' and xpath = '//*[@id="ctl00_ContentPlaceHolder1_tblGradesReceived"]/tbody/tr[2]'
-    link = "https://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20html%20where%20url%20%3D%20'https%3A%2F%2Fcape.ucsd.edu%2Fresponses%2FCAPEReport.aspx%3Fsectionid%3D" 
-            + sectionID 
-            + "'%20and%20xpath%3D'%2F%2F*%5B%40id%3D%22ctl00_ContentPlaceHolder1_tblGradesReceived%22%5D%2Ftbody%2Ftr%5B2%5D'&format=json&diagnostics=true&callback=";
-    
-    request.open('GET', link, false);
-    request.send(null);
+    this.fetchData(link, function(data){
+        var jsonObj;
+        var hrefValue;
+        var sectionID;
+        if(data !== null){
+            jsonObj = JSON.parse(data);
+            try{
+                hrefValue = jsonObj.query.results.a.href;
+                sectionID = hrefValue.substr(hrefValue.length-6);
+            }
+            catch(TypeError){
+                console.log("There was a TypeError getting the sectionID");
+                this.data = null;
+                return callback();
+            }
 
-    // only scrape the data if the page has successfully been retrieved and there is a sectionID
-    if(request.status == 200 && request.readyState == 4 && sectionID !== ""){
-        jsonObj = JSON.parse(request.responseText);
-        try{ 
-            this.data = {
-                // display data from cape website
-                aPercent: jsonObj.query.results.tr.td[0],
-                bPercent: jsonObj.query.results.tr.td[1],
-                cPercent: jsonObj.query.results.tr.td[2],
-                dPercent: jsonObj.query.results.tr.td[3],
-                fPercent: jsonObj.query.results.tr.td[4],
-                pPercent: jsonObj.query.results.tr.td[5],
-                npPercent:jsonObj.query.results.tr.td[6],
-                url: url
-            };        
+            // url to allow the user to go to the cape.ucsd.edu grade distribution site
+            var url = "http://cape.ucsd.edu/responses/CAPEReport.aspx?sectionid=" + sectionID;
+
+            // get grade distribution data and display it to the user
+            // YQL Query URL: select td from html where url = 'https://cape.ucsd.edu/responses/CAPEReport.aspx?sectionid=849783' and xpath = '//*[@id="ctl00_ContentPlaceHolder1_tblGradesReceived"]/tbody/tr[2]'
+            link = "https://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20html%20where%20url%20%3D%20'https%3A%2F%2Fcape.ucsd.edu%2Fresponses%2FCAPEReport.aspx%3Fsectionid%3D" 
+                    + sectionID 
+                    + "'%20and%20xpath%3D'%2F%2F*%5B%40id%3D%22ctl00_ContentPlaceHolder1_tblGradesReceived%22%5D%2Ftbody%2Ftr%5B2%5D'&format=json&diagnostics=true&callback="; 
+            // only get data if sectionID exists
+            if(sectionID !== undefined){
+                this.fetchData(link, function(data){
+                    console.log(data);
+                    jsonObj = JSON.parse(data);
+                    try{
+                        // only display data when page comes back successfully
+                        this.data = {
+                            // display data from cape website
+                            aPercent: jsonObj.query.results.tr.td[0],
+                            bPercent: jsonObj.query.results.tr.td[1],
+                            cPercent: jsonObj.query.results.tr.td[2],
+                            dPercent: jsonObj.query.results.tr.td[3],
+                            fPercent: jsonObj.query.results.tr.td[4],
+                            pPercent: jsonObj.query.results.tr.td[5],
+                            npPercent:jsonObj.query.results.tr.td[6],
+                            url: url
+                        };                                   
+                        return callback();       
+                    }
+                    catch(TypeError){
+                        console.log("There was a TypeError getting the grade data");
+                    }
+                }.bind(this));
+            }
+            else{
+                console.log("Unable to get grade distribution data. Compare the professor's name in the teacher param with cape.ucsd.edu");
+            }
         }
-        catch(TypeError){
-            console.log("There was a TypeError getting the grade data");
+        else{
+            console.log("Unable to get sectionID value");
         }
-    }
-    else{
-        console.log("Error loading grade dist info from cape.ucsd.edu. Compare the professor's name in the teacher param with cape.ucsd.edu");
-        // Display: "Grade Distribution data does not exist for this professor" instead of incorrect prof grade dist data
-        this.data = null;
-    }
-    return callback();
+    }.bind(this));
 };
-/**
- * Retrieves section ID - grade distribution data is available with a unique 6
- * digit sectionID in the url  
- * 
- * @param request - XMLHttpRequest object to get data with
- * @param link - cape.ucsd.edu link to extract sectionID value from
- * @return returns sectionID if successful, returns empty string if not
- */
-function getSectionID(request, link){
-    request.open('GET', link, false);  // `false` makes the request synchronous
-    request.send(null);
-    // only scrape the data if the page has successfully been retrieved
-    if (request.status == 200 && request.readyState == 4) {
-        try{
-            var jsonObj = JSON.parse(request.responseText);
-            var hrefValue = jsonObj.query.results.a.href;
-            // the section ID is the last 6 characters of hrefValue
-            return hrefValue.substr(hrefValue.length-6);
-        }
-        catch(TypeError){
-            console.log("TypeError getting the href value");
-            // return empty string as a result
-            return "";
-        }
-    }
-    else{
-        console.log("something went wrong");
-        // return empty string as a result
-        return "";
-    }   
-}

--- a/src/inject/gradeDist.js
+++ b/src/inject/gradeDist.js
@@ -14,11 +14,6 @@ GradeDist.prototype = Object.create(DataSection.prototype);
 GradeDist.prototype.constructor = GradeDist;
 
 GradeDist.prototype.getNewData = function (teacher, course, callback) {
-    // function that has to be here
-    this.fetchHTMLHttp("", function (page) {
-        return callback();
-    }.bind(this));
-
     // link to professor's cape.ucsd.edu site in order to get their 6 digit page number 
     // YQL Query URL: select href from html where url = 'https://cape.ucsd.edu/responses/Results.aspx?Name=mirza%2Cdiba&CourseNumber=cse30' and xpath = '//*[@id="ctl00_ContentPlaceHolder1_gvCAPEs_ctl02_hlViewReport"]'
     var link = "https://query.yahooapis.com/v1/public/yql?q=select%20href%20from%20html%20where%20url%3D%22https%3A%2F%2Fcape.ucsd.edu%2Fresponses%2FResults.aspx%3FName%3D" 
@@ -66,6 +61,7 @@ GradeDist.prototype.getNewData = function (teacher, course, callback) {
         // Display: "Grade Distribution data does not exist for this professor" instead of incorrect prof grade dist data
         this.data = null;
     }
+    return callback();
 };
 /**
  * Retrieves section ID - grade distribution data is available with a unique 6

--- a/src/inject/gradeDist.js
+++ b/src/inject/gradeDist.js
@@ -66,15 +66,21 @@ GradeDist.prototype.getNewData = function (teacher, course, callback) {
                     }
                     catch(TypeError){
                         console.log("There was a TypeError getting the grade data");
+                        this.data = null;
+                return callback();
                     }
                 }.bind(this));
             }
             else{
                 console.log("Unable to get grade distribution data. Compare the professor's name in the teacher param with cape.ucsd.edu");
+                this.data = null;
+                return callback();
             }
         }
         else{
             console.log("Unable to get sectionID value");
+            this.data = null;
+            return callback();
         }
     }.bind(this));
 };

--- a/src/inject/rmp.js
+++ b/src/inject/rmp.js
@@ -4,6 +4,7 @@ function RMP(errorHandler) {
         {label: 'Helpfulness', dataField: 'helpfulness'},
         {label: 'Clarity', dataField: 'clarity'},
         {label: 'Easiness', dataField: 'easiness'}
+        // adding a comment here
     ], 'Rate My Professor does not contain an entry for this professor.', errorHandler);
 
     //This is for teachers who have a different name on the class planner and RMP

--- a/src/inject/rmp.js
+++ b/src/inject/rmp.js
@@ -1,10 +1,8 @@
 function RMP(errorHandler) {
     DataSection.call(this, 'Rate My Professor', 'rmp', [
         {label: 'Overall Quality', dataField: 'overallQuality'},
-        {label: 'Helpfulness', dataField: 'helpfulness'},
-        {label: 'Clarity', dataField: 'clarity'},
-        {label: 'Easiness', dataField: 'easiness'}
-        // adding a comment here
+        {label: 'Would take again', dataField: 'wouldTakeAgain'},
+        {label: 'Level of Difficulty', dataField: 'levelOfDifficulty'}
     ], 'Rate My Professor does not contain an entry for this professor.', errorHandler);
 
     //This is for teachers who have a different name on the class planner and RMP
@@ -153,9 +151,8 @@ RMP.prototype.getTeacherInfo = function (id, callback) {
         var data = {};
         try {
             data.overallQuality = page.find('.rating-breakdown').find('.breakdown-wrapper').children().first().find('.grade').text();
-            data.helpfulness = $(page.find('.rating-breakdown').find('.faux-slides').children()[0]).find('.rating').text();
-            data.clarity = $(page.find('.rating-breakdown').find('.faux-slides').children()[1]).find('.rating').text();
-            data.easiness = $(page.find('.rating-breakdown').find('.faux-slides').children()[2]).find('.rating').text();
+            data.wouldTakeAgain = $(page.find('.rating-breakdown').find('.breakdown-wrapper').children()[1].children[0]).find('.grade').text();
+            data.levelOfDifficulty = $(page.find('.rating-breakdown').find('.breakdown-wrapper').children()[1].children[1]).find('.grade').text();
             data.url = url;
         } catch (e) {
             this.errorHandler.invariant();


### PR DESCRIPTION
This commit contains code that scrapes grade distribution data from the cape website. Compared to the other source for grade distribution data which is currently outdated.
## Development Notes:
- It's 76 lines shorter
- It's easier to read (in my opinion)
-  Uses YQL (Yahoo Query Language - https://developer.yahoo.com/yql/): This greatly simplifies the data scraping process and will make the app easier to maintain in the future. It will also help the performance of the app 
- Replaced Http with Https (see: https://www.httpvshttps.com/): This makes the app (slightly) faster and more secure
- The code is documented with javadoc conventions
- W and GPA labels have been removed: W is not a value in cape and GPA is already given under the CAPE column
- Synchronous XMLHttpRequest on the main thread is deprecated because of its detrimental effects to the end user's experience: is still present like before.
- There are some professors it's unable to get grade distribution data for. This is because of the difference in professor names on cape and the variables teacher.lname and teacher.fname (e.g. Ilkay Altintas, vs Ilkay Callaf). This is a problem we've addressed before and should not be very difficult to handle in the future
